### PR TITLE
Use `any` for unknown types

### DIFF
--- a/typescript-api-box.js
+++ b/typescript-api-box.js
@@ -243,9 +243,9 @@ function _type(data, skipSignature) {
 
   var typeName = _typeName(type);
   if (!typeName) {
-    console.error("unknown type name for", data.name);
+    console.error("unknown type name for", data.name, "using the type name `any`");
     // console.trace();
-    typeName = 'XXXX: unknown';
+    typeName = 'any';
   }
 
   if (type.typeArguments) {


### PR DESCRIPTION
This fixes the poor rendering behavior shown in the OP of: https://github.com/apollographql/core-docs/pull/252

There are some types which are very difficult to find sensible names for. Such as generic type parameters like in: `readQuery<T>(config): T`. If we wanted to use the name `T` we should probably also add the generic type parameter `<T>`, but that could be confusing for non-TypeScript devs. Instead we can just use a reasonable default of `any` while still logging that there is a problem.

This PR also propagates `undefined` returns from `_typeName` in union types as that is another bug which manifested itself in https://github.com/apollographql/core-docs/pull/252.

cc @stubailo, @helfer